### PR TITLE
Fix cleanup in GroupRepositoryTestSuite

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/service/ProductDbService.java
+++ b/src/main/java/com/kodilla/ecommercee/service/ProductDbService.java
@@ -5,15 +5,20 @@ import com.kodilla.ecommercee.repository.ProductRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class ProductDbService {
     @Autowired
     private ProductRepository productRepository;
 
     public void deleteById(Long id) {
-        Product product = productRepository.findById(id).get();
-        product.setGroup(null);
-        productRepository.save(product);
-        productRepository.delete(product);
+        Optional<Product> product = productRepository.findById(id);
+        if (!product.isPresent()) {
+            return;
+        }
+        product.get().setGroup(null);
+        productRepository.save(product.get());
+        productRepository.delete(product.get());
     }
 }

--- a/src/test/java/com/kodilla/ecommercee/repository/GroupRepositoryTestSuite.java
+++ b/src/test/java/com/kodilla/ecommercee/repository/GroupRepositoryTestSuite.java
@@ -25,6 +25,8 @@ public class GroupRepositoryTestSuite {
     private GroupDbService groupDbService;
     @Autowired
     private ProductDbService productDbService;
+    @Autowired
+    private ProductRepository productRepository;
 
     private Group getTestGroup() {
         String name = "dresses";
@@ -40,6 +42,14 @@ public class GroupRepositoryTestSuite {
         return dresses;
     }
 
+    private void cleanUp(Group group) {
+        group.getProducts().stream().forEach(p -> productDbService.deleteById(p.getId()));
+        groupDbService.deleteById(group.getId());
+
+        Assert.assertEquals(0, groupRepository.count());
+        Assert.assertEquals(0, productRepository.count());
+    }
+
     @Test
     public void testSaveGroupWithProducts() {
         //Given
@@ -49,14 +59,14 @@ public class GroupRepositoryTestSuite {
         groupRepository.save(group);
 
         //Then
-        Long id = group.getId();
-        Optional<Group> actualGroup = groupRepository.findById(id);
+        Long groupId = group.getId();
+        Optional<Group> actualGroup = groupRepository.findById(groupId);
         Assert.assertTrue(actualGroup.isPresent());
         Assert.assertEquals("dresses", actualGroup.get().getName());
         Assert.assertEquals(3, actualGroup.get().getProducts().size());
 
         //CleanUp
-        groupDbService.deleteById(id);
+        cleanUp(actualGroup.get());
     }
 
     @Test
@@ -76,7 +86,7 @@ public class GroupRepositoryTestSuite {
         Assert.assertEquals(2, actualGroup.get().getProducts().size());
 
         //CleanUp
-        groupDbService.deleteById(groupId);
+        cleanUp(actualGroup.get());
     }
 
     @Test
@@ -95,5 +105,8 @@ public class GroupRepositoryTestSuite {
         Optional<Group> actualGroup = groupRepository.findById(groupId);
         Assert.assertTrue(actualGroup.isPresent());
         Assert.assertEquals(newGroupName, actualGroup.get().getName());
+
+        //CleanUp
+        cleanUp(actualGroup.get());
     }
 }


### PR DESCRIPTION
Przesyłam do zaakceptowania drobną korektę testu - dodałam metodę, która w części cleanup usuwa zapisywane podczas testu dane w bazie danych.